### PR TITLE
.github: add `TagAlias` workflow for tagging aliases

### DIFF
--- a/.github/workflows/TagAlias.yml
+++ b/.github/workflows/TagAlias.yml
@@ -1,0 +1,21 @@
+name: TagAlias
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  TagAlias:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the major version
+        id: get_version
+        run: echo ::set-output name=major::$(echo $GITHUB_REF | grep -o 'v[[:digit:]]*')
+
+      - name: Tag the alias
+        uses: richardsimko/update-tag@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.major }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adopt the `TagAlias` workflow used by `julia-buildkite-plugin` [1], for updating the tags and tagging aliases.

[1] https://github.com/JuliaCI/julia-buildkite-plugin/blob/ced91aedc51b4e28830a59f8cfc40fd5dcfc2346/.github/workflows/TagAlias.yml