### PR TITLE
feat(pre-command): set `YTT_VERSION` to latest version if not specified

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -24,7 +24,7 @@ else
 fi
 
 # The version of YTT we're downloading
-YTT_VERSION="${BUILDKITE_PLUGIN_YTT_VERSION}"
+YTT_VERSION="${BUILDKITE_PLUGIN_YTT_VERSION:-$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/carvel-dev/ytt/releases/latest | awk -F/ '{print $NF}')}"
 # We allow the user to override the architecture we download
 ARCH="${BUILDKITE_PLUGIN_YTT_ARCH:-$(uname -m)}"
 


### PR DESCRIPTION
In case the version of ytt to be used isn't specified, simply set it to the latest version by default.